### PR TITLE
Fix YAML schema config loading suggestion

### DIFF
--- a/docs/extras/lang/yaml.md
+++ b/docs/extras/lang/yaml.md
@@ -79,8 +79,8 @@ opts = {
       },
       -- lazy-load schemastore when needed
       on_new_config = function(new_config)
-        new_config.settings.yaml.schemas = new_config.settings.yaml.schemas or {}
-        vim.list_extend(new_config.settings.yaml.schemas, require("schemastore").yaml.schemas())
+        new_config.settings.yaml.schemas =
+          vim.tbl_extend("keep", new_config.settings.yaml.schemas, require("schemastore").yaml.schemas())
       end,
       settings = {
         redhat = { telemetry = { enabled = false } },
@@ -131,8 +131,8 @@ opts = {
         },
         -- lazy-load schemastore when needed
         on_new_config = function(new_config)
-          new_config.settings.yaml.schemas = new_config.settings.yaml.schemas or {}
-          vim.list_extend(new_config.settings.yaml.schemas, require("schemastore").yaml.schemas())
+          new_config.settings.yaml.schemas =
+            vim.tbl_extend("keep", new_config.settings.yaml.schemas, require("schemastore").yaml.schemas())
         end,
         settings = {
           redhat = { telemetry = { enabled = false } },


### PR DESCRIPTION
The previous example code used `vim.list_extend` which had no effect in my configuration (`new_config.settings.yaml.schemas` remained an empty `{}` even though it was trying to extend with all the schemas from the `schemastore` plugin)